### PR TITLE
fix: shard name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uuidx
+# uuix
 
 A tiny (<1KB) and fast UUID (v4) generator for Crystal
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: uuid
+name: uuix
 version: 0.1.0
 
 authors:


### PR DESCRIPTION
Shard name did not match the dependency one, causing `shards install` to fail.
(Also there was a typo in the name on the readme)

closes: #2 